### PR TITLE
add missing parentheses to fix build errors

### DIFF
--- a/Src/SparseMatrix.inl
+++ b/Src/SparseMatrix.inl
@@ -463,7 +463,7 @@ SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( 
 	A.resize( aRows );
 	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
 	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
-	for( size_t i=0 ; i<A.rows ; i++ )
+	for( size_t i=0 ; i<A.rows() ; i++ )
 	{
 		size_t t = A.rowSizes[i];
 		A.rowSizes[i] = 0;
@@ -496,7 +496,7 @@ SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( 
 	A.resize( aRows );
 	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
 	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
-	for( size_t i=0 ; i<A.rows ; i++ )
+	for( size_t i=0 ; i<A.rows() ; i++ )
 	{
 		size_t t = A.rowSizes[i];
 		A.rowSizes[i] = 0;


### PR DESCRIPTION
## Proposed change

- I have added missing parentheses to fix build errors of https://github.com/isl-org/Open3D/commit/4356c172767a65209d2fe6dd76ff571f10293249 on Ubuntu 24.04. Below is the error message:

```log
[build] [ 71%] Building CXX object cpp/open3d/geometry/CMakeFiles/geometry.dir/SurfaceReconstructionPoisson.cpp.o
[build] In file included from /home/young/playground/Open3D/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp:32:
[build] In file included from /home/young/playground/Open3D/build/poisson/src/ext_poisson/PoissonRecon/Src/FEMTree.h:53:
[build] In file included from /home/young/playground/Open3D/build/poisson/src/ext_poisson/PoissonRecon/Src/SparseMatrix.h:153:
[build] /home/young/playground/Open3D/build/poisson/src/ext_poisson/PoissonRecon/Src/SparseMatrix.inl:466:24: error: reference to non-static member function must be called
[build]   466 |         for( size_t i=0 ; i<A.rows ; i++ )
[build]       |                             ~~^~~~
[build] /home/young/playground/Open3D/build/poisson/src/ext_poisson/PoissonRecon/Src/SparseMatrix.inl:499:24: error: reference to non-static member function must be called
[build]   499 |         for( size_t i=0 ; i<A.rows ; i++ )
[build]       |                             ~~^~~~
[build] 2 errors generated.
[build] gmake[2]: *** [cpp/open3d/geometry/CMakeFiles/geometry.dir/build.make:412: cpp/open3d/geometry/CMakeFiles/geometry.dir/SurfaceReconstructionPoisson.cpp.o] Error 1
```