### PR TITLE
Fix transpose function to use method call for row count in SparseMatrix

### DIFF
--- a/Src/SparseMatrix.inl
+++ b/Src/SparseMatrix.inl
@@ -463,7 +463,7 @@ SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( 
 	A.resize( aRows );
 	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
 	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
-	for( size_t i=0 ; i<A.rows ; i++ )
+	for( size_t i=0 ; i<A.rows() ; i++ )
 	{
 		size_t t = A.rowSizes[i];
 		A.rowSizes[i] = 0;
@@ -496,7 +496,7 @@ SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( 
 	A.resize( aRows );
 	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
 	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
-	for( size_t i=0 ; i<A.rows ; i++ )
+	for( size_t i=0 ; i<A.rows() ; i++ )
 	{
 		size_t t = A.rowSizes[i];
 		A.rowSizes[i] = 0;


### PR DESCRIPTION
Resolved the issue with the method call. Minor change, however it was raising the following error while building and installing the library:

<img width="1677" height="761" alt="Screenshot 2025-08-02 at 00 18 29" src="https://github.com/user-attachments/assets/7c8f79b4-f00c-4784-988e-dfcdb17f7590" />
